### PR TITLE
Add option to pass skipFetchSetup as optional

### DIFF
--- a/src/etherspot.ts
+++ b/src/etherspot.ts
@@ -34,7 +34,10 @@ export class EtherspotWallet extends UserOperationBuilder {
   private constructor(signer: EOASigner, rpcUrl: string, opts?: IPresetBuilderOpts) {
     super()
     this.signer = signer
-    this.provider = new BundlerJsonRpcProvider(rpcUrl).setBundlerRpc(opts?.overrideBundlerRpc)
+    this.provider = new BundlerJsonRpcProvider({
+      url: rpcUrl,
+      skipFetchSetup: opts?.skipFetchSetup || false,
+    }).setBundlerRpc(opts?.overrideBundlerRpc)
     this.entryPoint = EntryPoint__factory.connect(
       opts?.entryPoint || ERC4337.EntryPoint,
       this.provider

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -100,8 +100,8 @@ export class FuseSDK {
       jwtToken,
       signature,
       baseUrl = Variables.BASE_URL,
-      isTestnet = false
-      skipFetchSetup = false
+      isTestnet = false,
+      skipFetchSetup = false,
     }: {
       withPaymaster?: boolean
       paymasterContext?: Record<string, unknown>
@@ -117,22 +117,23 @@ export class FuseSDK {
     const fuseSDK = new FuseSDK(publicApiKey, baseUrl)
 
     if (isEOASigner(credentials)) {
-      await fuseSDK._initializeEtherspotWallet(
-        publicApiKey,
-        credentials,
-        {
-          withPaymaster,
-          paymasterContext,
-          opts,
-          clientOpts,
-          jwtToken,
-          signature,
-          baseUrl,
-          skipFetchSetup,
-        }
-      )
+      await fuseSDK._initializeEtherspotWallet(publicApiKey, credentials, {
+        withPaymaster,
+        paymasterContext,
+        opts,
+        clientOpts,
+        jwtToken,
+        signature,
+        baseUrl,
+        skipFetchSetup,
+      })
     } else {
-      const pimlico = new Pimlico(credentials, FuseSDK._getBundlerRpc(publicApiKey, baseUrl, BundlerProvider.Pimlico), withPaymaster, isTestnet)
+      const pimlico = new Pimlico(
+        credentials,
+        FuseSDK._getBundlerRpc(publicApiKey, baseUrl, BundlerProvider.Pimlico),
+        withPaymaster,
+        isTestnet
+      )
       fuseSDK.client = await pimlico.smartAccountClient()
     }
 
@@ -318,6 +319,7 @@ export class FuseSDK {
       jwtToken,
       signature,
       baseUrl = Variables.BASE_URL,
+      skipFetchSetup = false,
     }: {
       withPaymaster?: boolean
       paymasterContext?: Record<string, unknown>
@@ -326,6 +328,7 @@ export class FuseSDK {
       jwtToken?: string
       signature?: string
       baseUrl?: string
+      skipFetchSetup?: boolean
     } = {}
   ): Promise<EtherspotWallet> {
     let paymasterMiddleware: UserOperationMiddlewareFn | undefined
@@ -347,10 +350,10 @@ export class FuseSDK {
         paymasterMiddleware: opts?.paymasterMiddleware ?? paymasterMiddleware,
         overrideBundlerRpc: opts?.overrideBundlerRpc,
         nonceKey: opts?.nonceKey,
+        skipFetchSetup,
       },
       signature
     )
-
 
     if (jwtToken) {
       this._jwtToken = jwtToken
@@ -366,7 +369,11 @@ export class FuseSDK {
    * @param publicApiKey is required to authenticate with the Fuse API.
    * @returns
    */
-  private static _getBundlerRpc(publicApiKey: string, baseUrl: string, provider: BundlerProvider = BundlerProvider.Etherspot): string {
+  private static _getBundlerRpc(
+    publicApiKey: string,
+    baseUrl: string,
+    provider: BundlerProvider = BundlerProvider.Etherspot
+  ): string {
     return `https://${baseUrl}/api/v0/bundler?apiKey=${publicApiKey}&provider=${provider}`
   }
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -101,6 +101,7 @@ export class FuseSDK {
       signature,
       baseUrl = Variables.BASE_URL,
       isTestnet = false
+      skipFetchSetup = false
     }: {
       withPaymaster?: boolean
       paymasterContext?: Record<string, unknown>
@@ -110,6 +111,7 @@ export class FuseSDK {
       signature?: string
       baseUrl?: string
       isTestnet?: boolean
+      skipFetchSetup?: boolean
     } = {}
   ): Promise<FuseSDK> {
     const fuseSDK = new FuseSDK(publicApiKey, baseUrl)
@@ -126,6 +128,7 @@ export class FuseSDK {
           jwtToken,
           signature,
           baseUrl,
+          skipFetchSetup,
         }
       )
     } else {


### PR DESCRIPTION
Issue with Next.js api routes can't detect network error , reference: https://github.com/ethers-io/ethers.js/issues/4469